### PR TITLE
Remove unused color_order

### DIFF
--- a/stree
+++ b/stree
@@ -98,8 +98,6 @@ my @files;
 my @fromfile_dirs;
 my @units = qw(B KB MB GB TB PB EB ZB YB RB QB);
 my @field_order = qw(prefix inode device perms user group   date size  path suffix hash);
-my @color_order =   (WHITE  BLUE  YELLOW GREEN RED  MAGENTA CYAN WHITE RED  YELLOW WHITE);
-
 my @gitignore_patterns;
 
 my %seen_links;


### PR DESCRIPTION
## Summary
- delete leftover `@color_order` array in `stree`
- confirm there are no remaining `color_order` references

## Testing
- `perl -c stree`

------
https://chatgpt.com/codex/tasks/task_e_683f50100af08328ac73031c4b35b0a0