### PR TITLE
Add tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: '5.38'
+      - name: Install dependencies
+        run: |
+          cpanm -n Cpanel::JSON::XS Getopt::Long::Descriptive HTML::Tiny Sort::Versions Text::CSV YAML::XS XML::Writer Test::More File::Temp
+      - name: Syntax check
+        run: perl -c stree
+      - name: Run tests
+        run: prove -l

--- a/stree
+++ b/stree
@@ -30,7 +30,7 @@ $Term::ANSIColor::AUTORESET = 1;
 our $AUTHOR  = "Sean Evans";
 our $VERSION = "0.1.1";
 
-my ($opt, $usage) = describe_options(
+our ($opt, $usage) = describe_options(
   "$0 (v$VERSION) %o [directory]",
   [           'help|?',   "Prints the help information and exits." ],
   [        'version|!',   "Prints the version information and exits." ],
@@ -85,7 +85,7 @@ if ($opt->version) { say "$0 v$VERSION"; exit }
 my $dir = shift || '.';
 die "$!\n" unless -d $dir && -r $dir;
 
-my $output = \*STDOUT;
+our $output = \*STDOUT;
 my $current_depth = 0;
 my $log1024 = log(1024);
 my $partial_size = $opt->partial || 256;
@@ -485,6 +485,8 @@ sub wanted {
 }
 
 
+sub run
+{
 # --gitignore
 if ($opt->gitignore) {
   if (-e "$dir/.gitignore") {
@@ -538,3 +540,7 @@ close $output if $opt->output;
 
 say $output '';
 say $output BRIGHT_WHITE $num_dirs-1, ' directories, ', $num_files, ' files';
+
+}
+
+run() unless caller;

--- a/t/01_option_parse.t
+++ b/t/01_option_parse.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+
+# suppress redefine warnings when loading script multiple times
+local $SIG{__WARN__} = sub {};
+
+# --csv
+{
+    local @ARGV = ('--csv');
+    do "$FindBin::Bin/../stree";
+    ok($main::opt->{csv}, 'csv option parsed');
+}
+
+# --json
+{
+    local @ARGV = ('--json');
+    do "$FindBin::Bin/../stree";
+    ok($main::opt->{json}, 'json option parsed');
+}
+
+done_testing();

--- a/t/02_functions.t
+++ b/t/02_functions.t
@@ -1,0 +1,14 @@
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+
+local $SIG{__WARN__} = sub {};
+local @ARGV = ();
+do "$FindBin::Bin/../stree";
+
+is(human_readable_size(1024), '1.0 KB', 'human readable 1KB');
+is(format_permissions(0100644), '-rw-r--r--', 'format permissions 0644');
+is(format_permissions(0104755), '-rwsr-xr-x', 'format permissions setuid');
+
+done_testing();

--- a/t/03_gitignore.t
+++ b/t/03_gitignore.t
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+use File::Temp qw(tempdir tempfile);
+use Cpanel::JSON::XS qw(decode_json);
+
+local $SIG{__WARN__} = sub {};
+
+my $dir = tempdir(CLEANUP => 1);
+open my $fh, '>', "$dir/.gitignore" or die $!;
+print $fh "ignored\n";
+close $fh;
+open $fh, '>', "$dir/keep" or die $!; close $fh;
+open $fh, '>', "$dir/ignored" or die $!; close $fh;
+
+my ($tmpfh, $tmpfile) = tempfile();
+{
+    local *STDOUT = $tmpfh;
+    local @ARGV = ('--json','--gitignore',$dir);
+    do "$FindBin::Bin/../stree";
+    main::run();
+}
+close $tmpfh;
+
+open my $rfh, '<', $tmpfile or die $!;
+my $content = do { local $/; <$rfh> };
+close $rfh;
+
+# remove ANSI color codes
+$content =~ s/\e\[[0-9;]*m//g;
+
+my ($json_line) = $content =~ /(\[.*\])/s;
+my $files = decode_json($json_line);
+
+ok(!grep(/ignored$/, @$files), 'ignored file filtered');
+ok(grep(/keep$/,   @$files), 'kept file present');
+
+done_testing();


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for perl linting and tests
- expose internals from `stree` for tests and wrap program logic in `run`
- add unit tests for option parsing, helper functions and gitignore filtering

## Testing
- `perl -c stree`
- `prove -l`

------
https://chatgpt.com/codex/tasks/task_e_6840c2eb0e9c832885d98fbf5b734566