### PR TITLE
Add typical temp and coverage files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,14 @@
 *.bak
+# Editor temporary files
+*~
+*.swp
+*.swo
+*.tmp
+*.temp
+# System files
+.DS_Store
+Thumbs.db
+# Logs and coverage reports
+*.log
+coverage/
+coverage.*


### PR DESCRIPTION
## Summary
- ignore vim swap files, editor backup files, and system temp files
- optionally ignore log files and coverage directories

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840c2edfea88328ad2e3f7129bfe5dd