### PR TITLE
Refactor suffix file tests

### DIFF
--- a/stree
+++ b/stree
@@ -118,6 +118,33 @@ my $sk = 'rwxoRWXOezsfdlpSbctugkTB';
 my $sv = '<>*!{}#^"-%./$|=@+:~`&[]';
 my %sufs = map { substr($sk, $_, 1) => substr($sv, $_, 1) } 0 .. length($sk)-1;
 
+my %file_tests = (
+  r => sub { -r $_[0] },
+  w => sub { -w $_[0] },
+  x => sub { -x $_[0] },
+  o => sub { -o $_[0] },
+  R => sub { -R $_[0] },
+  W => sub { -W $_[0] },
+  X => sub { -X $_[0] },
+  O => sub { -O $_[0] },
+  e => sub { -e $_[0] },
+  z => sub { -z $_[0] },
+  s => sub { -s $_[0] },
+  f => sub { -f $_[0] },
+  d => sub { -d $_[0] },
+  l => sub { -l $_[0] },
+  p => sub { -p $_[0] },
+  S => sub { -S $_[0] },
+  b => sub { -b $_[0] },
+  c => sub { -c $_[0] },
+  t => sub { -t $_[0] },
+  u => sub { -u $_[0] },
+  g => sub { -g $_[0] },
+  k => sub { -k $_[0] },
+  T => sub { -T $_[0] },
+  B => sub { -B $_[0] },
+);
+
 my %colors = (
   prefix => (BOLD WHITE),
   inode  => BLUE,       # -n
@@ -158,9 +185,10 @@ sub human_readable_size {
 
 sub suffix {
   my $ret = '';
-
+  
   for (keys %sufs) {
-    $ret .= $sufs{$_} if eval "-$_ \$_[0]";
+    my $test = $file_tests{$_} or next;
+    $ret .= $sufs{$_} if $test->($_[0]);
   }
 
   return $ret;


### PR DESCRIPTION
## Summary
- replace eval-based suffix file tests with hash of coderefs

## Testing
- `perl -c stree`
- `prove -l`


------
https://chatgpt.com/codex/tasks/task_e_6893c4d0c29883288cdb8bedf5f8aa44