### PR TITLE
Handle empty directory counts in summary

### DIFF
--- a/stree
+++ b/stree
@@ -536,8 +536,10 @@ yaml(\@files, $output) if $opt->yaml;
 
 close $output if $opt->output;
 
+my $dir_count = $num_dirs > 0 ? $num_dirs - 1 : 0;
+
 say $output '';
-say $output BRIGHT_WHITE $num_dirs-1, ' directories, ', $num_files, ' files';
+say $output BRIGHT_WHITE $dir_count, ' directories, ', $num_files, ' files';
 
 }
 


### PR DESCRIPTION
## Summary
- Avoid negative directory counts in `run` by computing `$dir_count` before reporting results.

## Testing
- `prove -lr t`


------
https://chatgpt.com/codex/tasks/task_e_6893c4d2a4b883288746d468ef67c457