### PR TITLE
Handle missing Parse::Gitignore module

### DIFF
--- a/stree
+++ b/stree
@@ -18,13 +18,14 @@ use User::grent;
 use User::pwent;
 
 use Cpanel::JSON::XS;
-use Parse::Gitignore;
 use Getopt::Long::Descriptive;
 use HTML::Tiny;
 use Sort::Versions;
 use Text::CSV;
 use YAML::XS;
 use XML::Writer;
+
+my $has_parse_gitignore = eval { require Parse::Gitignore; 1 };
 
 $Term::ANSIColor::AUTORESET = 1;
 
@@ -524,6 +525,7 @@ sub run
 {
 # --gitignore
 if ($opt->gitignore) {
+  die "Parse::Gitignore module required for --gitignore option\n" unless $has_parse_gitignore;
   $gitignore = Parse::Gitignore->new();
   $gitignore->read_gitignore("$dir/.gitignore") if -e "$dir/.gitignore";
   if (my $git_dir = $ENV{GIT_DIR} // "$dir/.git") {

--- a/t/03_gitignore.t
+++ b/t/03_gitignore.t
@@ -5,6 +5,10 @@ use FindBin;
 use File::Temp qw(tempdir tempfile);
 use Cpanel::JSON::XS qw(decode_json);
 
+BEGIN {
+    eval { require Parse::Gitignore; 1 } or plan skip_all => 'Parse::Gitignore module required';
+}
+
 local $SIG{__WARN__} = sub {};
 
 my $dir = tempdir(CLEANUP => 1);


### PR DESCRIPTION
## Summary
- Load Parse::Gitignore only when available and required
- Skip gitignore tests when Parse::Gitignore is absent

## Testing
- `perl -c stree`
- `prove -l t/*.t`


------
https://chatgpt.com/codex/tasks/task_e_68a0fe6d879883289c148c06ec9580d4